### PR TITLE
Fix file handling and method naming

### DIFF
--- a/app/components/chat/Chat.client.tsx
+++ b/app/components/chat/Chat.client.tsx
@@ -162,7 +162,7 @@ export const ChatImpl = memo(({ initialMessages, storeMessageHistory }: ChatProp
      */
     await workbenchStore.saveAllFiles();
 
-    const fileModifications = workbenchStore.getFileModifcations();
+    const fileModifications = workbenchStore.getFileModifications();
 
     chatStore.setKey('aborted', false);
 

--- a/app/lib/stores/files.ts
+++ b/app/lib/stores/files.ts
@@ -138,7 +138,8 @@ export class FilesStore {
         case 'remove_dir': {
           this.files.setKey(sanitizedPath, undefined);
 
-          for (const [direntPath] of Object.entries(this.files)) {
+          const currentFiles = this.files.get();
+          for (const direntPath of Object.keys(currentFiles)) {
             if (direntPath.startsWith(sanitizedPath)) {
               this.files.setKey(direntPath, undefined);
             }

--- a/app/lib/stores/workbench.ts
+++ b/app/lib/stores/workbench.ts
@@ -202,7 +202,7 @@ export class WorkbenchStore {
     }
   }
 
-  getFileModifcations() {
+  getFileModifications() {
     return this.#filesStore.getFileModifications();
   }
 


### PR DESCRIPTION
## Summary
- fix removal logic in `FilesStore` to iterate over stored files correctly
- rename `getFileModifcations` typo to `getFileModifications`
- update chat component to use renamed method

## Testing
- `pnpm run lint` *(fails: registry.npmjs.org blocked)*
- `pnpm run test` *(fails: registry.npmjs.org blocked)*
- `pnpm run typecheck` *(fails: registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684ece1ebbf88329a1daa1949a72434e