### PR TITLE
Add docs for starter templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,18 +14,25 @@ Claude, v0, etc are incredible- but you can't install packages, run backends or 
   - Interact with third-party APIs
   - Deploy to production from chat
   - Share your work via a URL
+  - Scaffold new projects from preconfigured templates (Astro, Next.js, or Svelte)
 
 - **AI with Environment Control**: Unlike traditional dev environments where the AI can only assist in code generation, Bolt.new gives AI models **complete control** over the entire  environment including the filesystem, node server, package manager, terminal, and browser console. This empowers AI agents to handle the entire app lifecycle—from creation to deployment.
 
 Whether you’re an experienced developer, a PM or designer, Bolt.new allows you to build production-grade full-stack applications with ease.
 
+
 For developers interested in building their own AI-powered development tools with WebContainers, check out the open-source Bolt codebase in this repo!
+
+### Project Templates
+
+Bolt ships with lightweight starter kits for Astro, Next.js, and Svelte. You can select a template by appending `?template=astro`, `?template=nextjs`, or `?template=svelte` to the URL when creating a new project.
 
 ## Tips and Tricks
 
 Here are some tips to get the most out of Bolt.new:
 
 - **Be specific about your stack**: If you want to use specific frameworks or libraries (like Astro, Tailwind, ShadCN, or any other popular JavaScript framework), mention them in your initial prompt to ensure Bolt scaffolds the project accordingly.
+- **Leverage starter templates**: Select from preconfigured Astro, Next.js, or Svelte templates when creating a project to quickly scaffold a working environment.
 
 - **Use the enhance prompt icon**: Before sending your prompt, try clicking the 'enhance' icon to have the AI model help you refine your prompt, then edit the results before submitting.
 

--- a/app/lib/templates/index.ts
+++ b/app/lib/templates/index.ts
@@ -1,0 +1,77 @@
+export interface Template {
+  name: string;
+  files: Record<string, string>;
+}
+
+export const templates: Record<string, Template> = {
+  astro: {
+    name: 'Astro',
+    files: {
+      'package.json': JSON.stringify(
+        {
+          name: 'astro-app',
+          type: 'module',
+          scripts: {
+            dev: 'astro dev',
+            build: 'astro build',
+            start: 'node ./dist'
+          }
+        },
+        null,
+        2
+      ) + '\n',
+      'README.md': '# Astro Starter Kit\n'
+    }
+  },
+  nextjs: {
+    name: 'Next.js',
+    files: {
+      'package.json': JSON.stringify(
+        {
+          name: 'next-app',
+          scripts: {
+            dev: 'next dev',
+            build: 'next build',
+            start: 'next start'
+          }
+        },
+        null,
+        2
+      ) + '\n',
+      'README.md': '# Next.js Starter Kit\n'
+    }
+  },
+  svelte: {
+    name: 'Svelte',
+    files: {
+      'package.json': JSON.stringify(
+        {
+          name: 'svelte-app',
+          scripts: {
+            dev: 'svelte-kit dev',
+            build: 'svelte-kit build',
+            preview: 'svelte-kit preview'
+          }
+        },
+        null,
+        2
+      ) + '\n',
+      'README.md': '# Svelte Starter Kit\n'
+    }
+  }
+};
+
+import { webcontainer } from '../webcontainer';
+import { WORK_DIR } from '~/utils/constants';
+
+export async function applyTemplate(name: keyof typeof templates) {
+  const template = templates[name];
+  if (!template) {
+    throw new Error(`Unknown template: ${name}`);
+  }
+
+  const wc = await webcontainer;
+  for (const [filePath, content] of Object.entries(template.files)) {
+    await wc.fs.writeFile(`${WORK_DIR}/${filePath}`, content);
+  }
+}

--- a/app/lib/webcontainer/index.ts
+++ b/app/lib/webcontainer/index.ts
@@ -1,5 +1,6 @@
 import { WebContainer } from '@webcontainer/api';
 import { WORK_DIR_NAME } from '~/utils/constants';
+import { applyTemplate, templates } from '../templates';
 
 interface WebContainerContext {
   loaded: boolean;
@@ -24,9 +25,21 @@ if (!import.meta.env.SSR) {
       .then(() => {
         return WebContainer.boot({ workdirName: WORK_DIR_NAME });
       })
-      .then((webcontainer) => {
+      .then(async (wc) => {
         webcontainerContext.loaded = true;
-        return webcontainer;
+
+        const params = new URLSearchParams(window.location.search);
+        const template = params.get('template');
+
+        if (template && template in templates) {
+          try {
+            await applyTemplate(template as keyof typeof templates);
+          } catch (error) {
+            console.error('Failed to apply template', error);
+          }
+        }
+
+        return wc;
       });
 
   if (import.meta.hot) {


### PR DESCRIPTION
## Summary
- document ability to scaffold projects from preconfigured templates
- mention starter templates in Tips & Tricks
- add starter template utilities and apply selected template on boot

## Testing
- `pnpm test` *(fails: Request was cancelled)*
- `pnpm lint` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684ed76f84388329871f949489958c0a